### PR TITLE
Using IP instead of URL for registerIPv4 config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -118,9 +118,7 @@ class AMFOperatorCharm(CharmBase):
         self._configure_amf_workload()
         self.unit.status = ActiveStatus()
 
-    def _generate_config_file(
-        self,
-    ) -> None:
+    def _generate_config_file(self) -> None:
         """Handles creation of the AMF config file.
 
         Generates AMF config file based on a given template.
@@ -133,7 +131,7 @@ class AMFOperatorCharm(CharmBase):
             sctp_grpc_port=SCTP_GRPC_PORT,
             sbi_port=SBI_PORT,
             nrf_url=self._nrf_requires.nrf_url,
-            amf_url=self._amf_hostname,
+            amf_ip=_get_pod_ip(),
             default_database_name=DEFAULT_DATABASE_NAME,
             amf_database_name=AMF_DATABASE_NAME,
             database_url=self._get_default_database_info()["uris"].split(",")[0],
@@ -151,7 +149,7 @@ class AMFOperatorCharm(CharmBase):
         *,
         default_database_name: str,
         amf_database_name: str,
-        amf_url: str,
+        amf_ip: str,
         ngapp_port: int,
         sctp_grpc_port: int,
         sbi_port: int,
@@ -165,7 +163,7 @@ class AMFOperatorCharm(CharmBase):
         Args:
             default_database_name (str): Name of the default (free5gc) database.
             amf_database_name (str): Name of the AMF database.
-            amf_url (str): URL of the AMF.
+            amf_ip (str): IP address of the AMF.
             ngapp_port (int): AMF NGAP port.
             sctp_grpc_port (int): AMF SCTP port.
             sbi_port (int): AMF SBi port.
@@ -184,7 +182,7 @@ class AMFOperatorCharm(CharmBase):
             sctp_grpc_port=sctp_grpc_port,
             sbi_port=sbi_port,
             nrf_url=nrf_url,
-            amf_url=amf_url,
+            amf_ip=amf_ip,
             default_database_name=default_database_name,
             amf_database_name=amf_database_name,
             database_url=database_url,
@@ -300,27 +298,19 @@ class AMFOperatorCharm(CharmBase):
             "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
             "GRPC_TRACE": "all",
             "GRPC_VERBOSITY": "DEBUG",
-            "POD_IP": self._get_pod_ip(),
+            "POD_IP": _get_pod_ip(),
             "MANAGED_BY_CONFIG_POD": "true",
         }
 
-    def _get_pod_ip(self) -> str:
-        """Returns the pod IP using juju client.
 
-        Returns:
-            str: The pod IP.
-        """
-        return str(IPv4Address(check_output(["unit-get", "private-address"]).decode().strip()))
+def _get_pod_ip() -> str:
+    """Returns the pod IP using juju client.
 
-    @property
-    def _amf_hostname(self) -> str:
-        """Builds and returns the AMF hostname in the cluster.
-
-        Returns:
-            str: The AMF hostname.
-        """
-        return f"{self.model.app.name}.{self.model.name}.svc.cluster.local"
+    Returns:
+        str: The pod IP.
+    """
+    return str(IPv4Address(check_output(["unit-get", "private-address"]).decode().strip()))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main(AMFOperatorCharm)

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -23,7 +23,7 @@ configuration:
   sbi:
     bindingIPv4: 0.0.0.0
     port: {{ sbi_port }}
-    registerIPv4: {{ amf_url }}
+    registerIPv4: {{ amf_ip }}
     scheme: http
   sctpGrpcPort: {{ sctp_grpc_port }}
   serviceNameList:

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -23,7 +23,7 @@ configuration:
   sbi:
     bindingIPv4: 0.0.0.0
     port: 29518
-    registerIPv4: sdcore-amf.whatever.svc.cluster.local
+    registerIPv4: 1.1.1.1
     scheme: http
   sctpGrpcPort: 9000
   serviceNameList:


### PR DESCRIPTION
# Description

Uses pod IP instead of URL for registerIPv4 config

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library