### PR TITLE
[Bug fix] AMF only relies on 1 database "sdcore_amf"

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,7 +33,5 @@ provides:
 requires:
   fiveg_nrf:
     interface: fiveg_nrf
-  default-database:
-    interface: mongodb_client
-  amf-database:
+  database:
     interface: mongodb_client

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,7 @@ PROMETHEUS_PORT = 9089
 SBI_PORT = 29518
 NGAPP_PORT = 38412
 SCTP_GRPC_PORT = 9000
-AMF_DATABASE_NAME = "sdcore_amf"
+DATABASE_NAME = "sdcore_amf"
 CONFIG_DIR_PATH = "/free5gc/config"
 CONFIG_FILE_NAME = "amfcfg.conf"
 CONFIG_TEMPLATE_DIR_PATH = "src/templates/"
@@ -57,12 +57,9 @@ class AMFOperatorCharm(CharmBase):
             ],
         )
         self._database = DatabaseRequires(
-            self, relation_name="database", database_name=AMF_DATABASE_NAME
+            self, relation_name="database", database_name=DATABASE_NAME
         )
-        self.framework.observe(
-            self.on.database_relation_joined,
-            self._configure_amf,
-        )
+        self.framework.observe(self.on.database_relation_joined, self._configure_amf)
         self.framework.observe(self._database.on.database_created, self._configure_amf)
         self.framework.observe(self.on.amf_pebble_ready, self._configure_amf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_amf)
@@ -118,7 +115,7 @@ class AMFOperatorCharm(CharmBase):
             sbi_port=SBI_PORT,
             nrf_url=self._nrf_requires.nrf_url,
             amf_ip=_get_pod_ip(),
-            database_name=AMF_DATABASE_NAME,
+            database_name=DATABASE_NAME,
             database_url=self._get_database_info()["uris"].split(",")[0],
             full_network_name=CORE_NETWORK_FULL_NAME,
             short_network_name=CORE_NETWORK_SHORT_NAME,
@@ -248,7 +245,7 @@ class AMFOperatorCharm(CharmBase):
             Dict: The database data.
         """
         if not self._database_is_available():
-            raise RuntimeError(f"Database `{AMF_DATABASE_NAME}` is not available")
+            raise RuntimeError(f"Database `{DATABASE_NAME}` is not available")
         return self._database.fetch_relation_data()[self._database.relations[0].id]
 
     def _database_is_available(self) -> bool:

--- a/src/charm.py
+++ b/src/charm.py
@@ -118,7 +118,7 @@ class AMFOperatorCharm(CharmBase):
             sbi_port=SBI_PORT,
             nrf_url=self._nrf_requires.nrf_url,
             amf_ip=_get_pod_ip(),
-            amf_database_name=AMF_DATABASE_NAME,
+            database_name=AMF_DATABASE_NAME,
             database_url=self._get_database_info()["uris"].split(",")[0],
             full_network_name=CORE_NETWORK_FULL_NAME,
             short_network_name=CORE_NETWORK_SHORT_NAME,
@@ -132,7 +132,7 @@ class AMFOperatorCharm(CharmBase):
     @staticmethod
     def _render_config_file(
         *,
-        amf_database_name: str,
+        database_name: str,
         amf_ip: str,
         ngapp_port: int,
         sctp_grpc_port: int,
@@ -145,7 +145,7 @@ class AMFOperatorCharm(CharmBase):
         """Renders the AMF config file.
 
         Args:
-            amf_database_name (str): Name of the AMF database.
+            database_name (str): Name of the AMF database.
             amf_ip (str): IP address of the AMF.
             ngapp_port (int): AMF NGAP port.
             sctp_grpc_port (int): AMF SCTP port.
@@ -166,7 +166,7 @@ class AMFOperatorCharm(CharmBase):
             sbi_port=sbi_port,
             nrf_url=nrf_url,
             amf_ip=amf_ip,
-            amf_database_name=amf_database_name,
+            database_name=database_name,
             database_url=database_url,
             full_network_name=full_network_name,
             short_network_name=short_network_name,

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -5,7 +5,6 @@ configuration:
   enableDBStore: false
   enableSctpLb: false
   mongodb:
-    name: free5gc
     url: {{ database_url }}
   networkFeatureSupport5GS:
     emc: 0

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -1,5 +1,5 @@
 configuration:
-  amfDBName: {{ amf_database_name }}
+  amfDBName: {{ database_name }}
   amfName: AMF
   debugProfilePort: 5001
   enableDBStore: false

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -5,7 +5,7 @@ configuration:
   enableDBStore: false
   enableSctpLb: false
   mongodb:
-    name: {{ default_database_name }}
+    name: free5gc
     url: {{ database_url }}
   networkFeatureSupport5GS:
     emc: 0

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -66,10 +66,7 @@ async def test_relate_and_wait_for_active_status(
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
     await ops_test.model.add_relation(
-        relation1=f"{APP_NAME}:default-database", relation2=f"{DB_CHARM_NAME}"
-    )
-    await ops_test.model.add_relation(
-        relation1=f"{APP_NAME}:amf-database", relation2=f"{DB_CHARM_NAME}"
+        relation1=f"{APP_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)
     await ops_test.model.wait_for_idle(

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -5,7 +5,6 @@ configuration:
   enableDBStore: false
   enableSctpLb: false
   mongodb:
-    name: free5gc
     url: http://dummy
   networkFeatureSupport5GS:
     emc: 0


### PR DESCRIPTION
# Description

- Removes the default database that was never used in the charm
- Uses the URL from the "sdcore_amf" database to enter into the amf configuration file

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library