### PR TITLE
[Bug fix] Adds job to metrics endpoint provider

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,14 @@ class AMFOperatorCharm(CharmBase):
         self._amf_container = self.unit.get_container(self._amf_container_name)
         self._nrf_requires = NRFRequires(charm=self, relation_name="fiveg_nrf")
         self.n2_provider = N2Provides(self, N2_RELATION_NAME)
-        self._amf_metrics_endpoint = MetricsEndpointProvider(self)
+        self._amf_metrics_endpoint = MetricsEndpointProvider(
+            self,
+            jobs=[
+                {
+                    "static_configs": [{"targets": [f"*:{PROMETHEUS_PORT}"]}],
+                }
+            ],
+        )
         self._service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[


### PR DESCRIPTION
# Description

AMF metrics weren't forwarded to Grafana Agent and prometheus. This PR adds a job to metrics endpoint provider to do exactly that.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library