### PR TITLE
Expose NGAPP port as a Loadbalancer Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ juju deploy self-signed-certificates --channel=edge
 juju integrate sdcore-amf:certificates self-signed-certificates:certificates
 ```
 
+### Overriding external access information for N2 interface
+
+By default, the N2 connection information sent to the RAN will be taken from
+the created `LoadBalancer` Kubernetes Service. If this is not appropriate with
+your network configuration, you can override that information through
+configuration:
+
+```bash
+juju config sdcore-amf external-amf-ip=192.168.0.4 external-amf-hostname=amf.example.com
+```
+
 ## Image
 
 **amf**: ghcr.io/canonical/sdcore-amf:1.3

--- a/config.yaml
+++ b/config.yaml
@@ -3,12 +3,12 @@ options:
     type: string
     default: internet
     description: Data Network Name (DNN)
-  amf-ip:
+  external-amf-ip:
     type: string
     description: |-
       Externally accessible IP for the AMF.
       If not provided, this will default to the LoadBalancer Service IP.
-  amf-hostname:
+  external-amf-hostname:
     type: string
     description: |-
       Externally accessible FQDN for the AMF.

--- a/config.yaml
+++ b/config.yaml
@@ -3,3 +3,15 @@ options:
     type: string
     default: internet
     description: Data Network Name (DNN)
+  amf-ip:
+    type: string
+    description: |-
+      Externally accessible IP for the AMF.
+      If not provided, this will default to the LoadBalancer Service IP.
+  amf-hostname:
+    type: string
+    description: |-
+      Externally accessible FQDN for the AMF.
+      If not provided, this will default to the LoadBalancer Service hostname
+      if available. If that is not available, it will default to the internal
+      Kubernetes FQDN of the service.

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,6 @@ class AMFOperatorCharm(CharmBase):
 
     def _on_install(self, event: InstallEvent) -> None:
         client = Client()
-        logger.info("Creating external AMF service")
         client.create(
             Service(
                 apiVersion="v1",
@@ -133,15 +132,16 @@ class AMFOperatorCharm(CharmBase):
                 ),
             )
         )
+        logger.info("Created external AMF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:
         client = Client()
-        logger.info("Removing external AMF service")
         client.delete(
             Service,
             namespace=self.model.name,
             name=f"{self.app.name}-external",
         )
+        logger.info("Removed external AMF service")
 
     def _configure_amf(self, event: EventBase) -> None:
         """Handle pebble ready event for AMF container.
@@ -341,11 +341,11 @@ class AMFOperatorCharm(CharmBase):
     def _get_dnn_config(self) -> Optional[str]:
         return self.model.config.get("dnn")
 
-    def _get_amf_ip_config(self) -> Optional[str]:
-        return self.model.config.get("amf-ip")
+    def _get_external_amf_ip_config(self) -> Optional[str]:
+        return self.model.config.get("external-amf-ip")
 
-    def _get_amf_hostname_config(self) -> Optional[str]:
-        return self.model.config.get("amf-hostname")
+    def _get_external_amf_hostname_config(self) -> Optional[str]:
+        return self.model.config.get("external-amf-hostname")
 
     def _on_n2_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Handles N2 relation joined event.
@@ -364,7 +364,7 @@ class AMFOperatorCharm(CharmBase):
         Returns:
             str: IP address of the AMF
         """
-        if configured_ip := self._get_amf_ip_config():
+        if configured_ip := self._get_external_amf_ip_config():
             return configured_ip
         return self._amf_external_service_ip()
 
@@ -379,7 +379,7 @@ class AMFOperatorCharm(CharmBase):
         Returns:
             str: Hostname of the AMF
         """
-        if configured_hostname := self._get_amf_hostname_config():
+        if configured_hostname := self._get_external_amf_hostname_config():
             return configured_hostname
         elif lb_hostname := self._amf_external_service_hostname():
             return lb_hostname

--- a/src/charm.py
+++ b/src/charm.py
@@ -608,11 +608,17 @@ class AMFOperatorCharm(CharmBase):
             str: External Service IP
         """
         client = Client()
-        service = client.get(Service, name="amf-external", namespace=self.model.name)
+        service = client.get(
+            Service, name=f"{self.model.app.name}-external", namespace=self.model.name
+        )
         try:
-            return service.status.loadbalancer.ingress[0].ip  # type: ignore[attr-defined]
+            return service.status.loadBalancer.ingress[0].ip  # type: ignore[attr-defined]
         except AttributeError:
-            logger.error("Service 'amf-external' does not have an IP address")
+            logger.error(
+                "Service '%s-external' does not have an IP address:\n%s",
+                self.model.app.name,
+                service,
+            )
             return ""
 
     def _amf_external_service_hostname(self) -> str:
@@ -622,11 +628,17 @@ class AMFOperatorCharm(CharmBase):
             str: External Service hostname
         """
         client = Client()
-        service = client.get(Service, name="amf-external", namespace=self.model.name)
+        service = client.get(
+            Service, name=f"{self.model.app.name}-external", namespace=self.model.name
+        )
         try:
-            return service.status.loadbalancer.ingress[0].hostname  # type: ignore[attr-defined]
+            return service.status.loadBalancer.ingress[0].hostname  # type: ignore[attr-defined]
         except AttributeError:
-            logger.error("Service 'amf-external' does not have a hostname")
+            logger.error(
+                "Service '%s-external' does not have a hostname:\n%s",
+                self.model.app.name,
+                service,
+            )
             return ""
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -368,7 +368,10 @@ class TestCharm(unittest.TestCase):
         self, patch_check_output, patch_get
     ):
         patch_check_output.return_value = b"1.1.1.1"
-        patch_get.status.loadbalancer.ingress[0].ip.return_value = "1.1.1.1"
+        service = Mock(
+            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+        )
+        patch_get.return_value = service
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
         relation_data = self.harness.get_relation_data(
@@ -376,6 +379,7 @@ class TestCharm(unittest.TestCase):
         )
         self.assertEqual(relation_data, {})
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
@@ -398,7 +402,9 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
-        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1")])))
+        service = Mock(
+            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+        )
         patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
@@ -414,9 +420,100 @@ class TestCharm(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
         self.assertEqual(relation_data["amf_ip_address"], "1.1.1.1")
-        self.assertEqual(relation_data["amf_hostname"], "sdcore-amf.whatever.svc.cluster.local")
+        self.assertEqual(relation_data["amf_hostname"], "amf.pizza.com")
         self.assertEqual(relation_data["amf_port"], "38412")
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch("lightkube.core.client.Client.get")
+    @patch("ops.model.Container.pull")
+    @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.push")
+    @patch("charm.check_output")
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
+    def test_given_n2_information_and_service_is_running_and_n2_config_is_overriden_when_fiveg_n2_relation_joined_then_custom_n2_information_is_in_relation_databag(  # noqa: E501
+        self,
+        patch_is_resource_created,
+        patch_nrf_url,
+        patch_check_output,
+        patch_push,
+        patch_exists,
+        patch_pull,
+        patch_get,
+    ):
+        patch_pull.return_value = StringIO(
+            self._read_file("tests/unit/expected_config/config.conf").strip()
+        )
+        patch_exists.return_value = True
+        patch_check_output.return_value = b"1.1.1.1"
+        service = Mock(
+            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+        )
+        patch_get.return_value = service
+        patch_exists.return_value = True
+        patch_is_resource_created.return_value = True
+        patch_nrf_url.return_value = "http://nrf:8081"
+        self.harness.set_can_connect(container="amf", val=True)
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
+        self.harness.update_config({"amf-ip": "2.2.2.2", "amf-hostname": "amf.burger.com"})
+        self._database_is_available()
+        self.harness.container_pebble_ready("amf")
+
+        relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
+        relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name
+        )
+        self.assertEqual(relation_data["amf_ip_address"], "2.2.2.2")
+        self.assertEqual(relation_data["amf_hostname"], "amf.burger.com")
+        self.assertEqual(relation_data["amf_port"], "38412")
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
+    @patch("lightkube.core.client.Client.get")
+    @patch("ops.model.Container.pull")
+    @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.push")
+    @patch("charm.check_output")
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
+    def test_given_n2_information_and_service_is_running_and_lb_service_has_no_hostname_when_fiveg_n2_relation_joined_then_internal_service_hostname_is_used(  # noqa: E501
+        self,
+        patch_is_resource_created,
+        patch_nrf_url,
+        patch_check_output,
+        patch_push,
+        patch_exists,
+        patch_pull,
+        patch_get,
+    ):
+        patch_pull.return_value = StringIO(
+            self._read_file("tests/unit/expected_config/config.conf").strip()
+        )
+        patch_exists.return_value = True
+        patch_check_output.return_value = b"1.1.1.1"
+        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
+        patch_get.return_value = service
+        patch_exists.return_value = True
+        patch_is_resource_created.return_value = True
+        patch_nrf_url.return_value = "http://nrf:8081"
+        self.harness.set_can_connect(container="amf", val=True)
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
+        self.harness.update_config({"amf-ip": "2.2.2.2"})
+        self._database_is_available()
+        self.harness.container_pebble_ready("amf")
+
+        relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
+        relation_data = self.harness.get_relation_data(
+            relation_id=relation_id, app_or_unit=self.harness.charm.app.name
+        )
+        self.assertEqual(relation_data["amf_ip_address"], "2.2.2.2")
+        self.assertEqual(
+            relation_data["amf_hostname"], "sdcore-amf-external.whatever.svc.cluster.local"
+        )
+        self.assertEqual(relation_data["amf_port"], "38412")
+
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
@@ -446,7 +543,9 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
-        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1")])))
+        service = Mock(
+            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+        )
         patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
@@ -460,9 +559,10 @@ class TestCharm(unittest.TestCase):
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
         self.assertEqual(relation_data["amf_ip_address"], "1.1.1.1")
-        self.assertEqual(relation_data["amf_hostname"], "sdcore-amf.whatever.svc.cluster.local")
+        self.assertEqual(relation_data["amf_hostname"], "amf.pizza.com")
         self.assertEqual(relation_data["amf_port"], "38412")
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
@@ -482,7 +582,9 @@ class TestCharm(unittest.TestCase):
     ):
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
-        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1")])))
+        service = Mock(
+            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+        )
         patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
@@ -508,7 +610,7 @@ class TestCharm(unittest.TestCase):
             relation_id=relation_2_id, app_or_unit=self.harness.charm.app.name
         )
         self.assertEqual(relation_data["amf_ip_address"], "1.1.1.1")
-        self.assertEqual(relation_data["amf_hostname"], "sdcore-amf.whatever.svc.cluster.local")
+        self.assertEqual(relation_data["amf_hostname"], "amf.pizza.com")
         self.assertEqual(relation_data["amf_port"], "38412")
 
     @patch("charm.generate_private_key")
@@ -667,6 +769,7 @@ class TestCharm(unittest.TestCase):
 
         patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.create")
     def test_when_install_then_external_service_is_created(self, patch_create):
         self.harness.charm.on.install.emit()
@@ -697,6 +800,7 @@ class TestCharm(unittest.TestCase):
 
         patch_create.assert_has_calls(calls=calls)
 
+    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.delete")
     def test_when_remove_then_external_service_is_deleted(self, patch_delete):
         self.harness.charm.on.remove.emit()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -369,7 +369,7 @@ class TestCharm(unittest.TestCase):
     ):
         patch_check_output.return_value = b"1.1.1.1"
         service = Mock(
-            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+            status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
         patch_get.return_value = service
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
@@ -403,7 +403,7 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
         service = Mock(
-            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+            status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
         patch_get.return_value = service
         patch_exists.return_value = True
@@ -447,7 +447,7 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
         service = Mock(
-            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+            status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
         patch_get.return_value = service
         patch_exists.return_value = True
@@ -493,7 +493,7 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
-        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
+        service = Mock(status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
         patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
@@ -546,7 +546,7 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
         service = Mock(
-            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+            status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
         patch_get.return_value = service
         patch_exists.return_value = True
@@ -585,7 +585,7 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
         service = Mock(
-            status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
+            status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
         patch_get.return_value = service
         patch_exists.return_value = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -454,7 +454,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
         self.harness.update_config(
             {"external-amf-ip": "2.2.2.2", "external-amf-hostname": "amf.burger.com"}
         )
@@ -499,7 +499,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
         self.harness.update_config({"external-amf-ip": "2.2.2.2"})
         self._database_is_available()
         self.harness.container_pebble_ready("amf")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -455,7 +455,9 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
-        self.harness.update_config({"amf-ip": "2.2.2.2", "amf-hostname": "amf.burger.com"})
+        self.harness.update_config(
+            {"external-amf-ip": "2.2.2.2", "external-amf-hostname": "amf.burger.com"}
+        )
         self._database_is_available()
         self.harness.container_pebble_ready("amf")
 
@@ -498,7 +500,7 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
-        self.harness.update_config({"amf-ip": "2.2.2.2"})
+        self.harness.update_config({"external-amf-ip": "2.2.2.2"})
         self._database_is_available()
         self.harness.container_pebble_ready("amf")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,8 +3,11 @@
 
 import unittest
 from io import StringIO
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, call, patch
 
+from lightkube.models.core_v1 import ServicePort, ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
@@ -359,11 +362,13 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for pod IP address to be available"),
         )
 
+    @patch("lightkube.core.client.Client.get")
     @patch("charm.check_output")
     def test_given_service_not_running_when_fiveg_n2_relation_joined_then_n2_information_is_not_in_relation_databag(  # noqa: E501
-        self, patch_check_output
+        self, patch_check_output, patch_get
     ):
         patch_check_output.return_value = b"1.1.1.1"
+        patch_get.status.loadbalancer.ingress[0].ip.return_value = "1.1.1.1"
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
         relation_data = self.harness.get_relation_data(
@@ -371,6 +376,7 @@ class TestCharm(unittest.TestCase):
         )
         self.assertEqual(relation_data, {})
 
+    @patch("lightkube.core.client.Client.get")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.push")
@@ -385,12 +391,15 @@ class TestCharm(unittest.TestCase):
         patch_push,
         patch_exists,
         patch_pull,
+        patch_get,
     ):
         patch_pull.return_value = StringIO(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
+        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1")])))
+        patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
@@ -408,6 +417,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(relation_data["amf_hostname"], "sdcore-amf.whatever.svc.cluster.local")
         self.assertEqual(relation_data["amf_port"], "38412")
 
+    @patch("lightkube.core.client.Client.get")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.push")
@@ -422,6 +432,7 @@ class TestCharm(unittest.TestCase):
         patch_push,
         patch_exists,
         patch_pull,
+        patch_get,
     ):
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
@@ -435,6 +446,8 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
+        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1")])))
+        patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
@@ -450,6 +463,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(relation_data["amf_hostname"], "sdcore-amf.whatever.svc.cluster.local")
         self.assertEqual(relation_data["amf_port"], "38412")
 
+    @patch("lightkube.core.client.Client.get")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
     @patch("ops.model.Container.push")
@@ -464,9 +478,12 @@ class TestCharm(unittest.TestCase):
         patch_push,
         patch_exists,
         patch_pull,
+        patch_get,
     ):
         patch_exists.return_value = True
         patch_check_output.return_value = b"1.1.1.1"
+        service = Mock(status=Mock(loadbalancer=Mock(ingress=[Mock(ip="1.1.1.1")])))
+        patch_get.return_value = service
         patch_exists.return_value = True
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
@@ -649,3 +666,47 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_certificate_expiring(event=event)
 
         patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+
+    @patch("lightkube.core.client.Client.create")
+    def test_when_install_then_external_service_is_created(self, patch_create):
+        self.harness.charm.on.install.emit()
+
+        calls = [
+            call(
+                Service(
+                    apiVersion="v1",
+                    kind="Service",
+                    metadata=ObjectMeta(
+                        namespace=self.namespace,
+                        name=f"{self.harness.charm.app.name}-external",
+                    ),
+                    spec=ServiceSpec(
+                        selector={"app.kubernetes.io/name": self.harness.charm.app.name},
+                        ports=[
+                            ServicePort(
+                                name="ngapp",
+                                port=38412,
+                                protocol="SCTP",
+                            ),
+                        ],
+                        type="LoadBalancer",
+                    ),
+                )
+            ),
+        ]
+
+        patch_create.assert_has_calls(calls=calls)
+
+    @patch("lightkube.core.client.Client.delete")
+    def test_when_remove_then_external_service_is_deleted(self, patch_delete):
+        self.harness.charm.on.remove.emit()
+
+        calls = [
+            call(
+                Service,
+                namespace=self.namespace,
+                name=f"{self.harness.charm.app.name}-external",
+            ),
+        ]
+
+        patch_delete.assert_has_calls(calls=calls)


### PR DESCRIPTION
# Description

Expose the `NGAPP` port as a LoadBalancer Service to enable external access from edge RAN. Also add IP and hostname configuration items to allow the administrator to override the defaults for specific network configurations.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library