### PR TITLE
(FIX) Downgrading ops to 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==2.4.1
 lightkube
 lightkube-models
 pydantic


### PR DESCRIPTION
# Description

Pins `ops` version to 2.4.1, which is currently the last one compatible with `scenario`. Newer versions are causing integration and units tests failures.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library