### PR TITLE
(TELCO-574) block charm when NRF goes down

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -90,6 +90,7 @@ class AMFOperatorCharm(CharmBase):
         self.framework.observe(self._database.on.database_created, self._configure_amf)
         self.framework.observe(self.on.amf_pebble_ready, self._configure_amf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_amf)
+        self.framework.observe(self._nrf_requires.on.nrf_broken, self._on_nrf_broken)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_amf)
         self.framework.observe(self.on.fiveg_n2_relation_joined, self._on_n2_relation_joined)
         self.framework.observe(
@@ -108,10 +109,7 @@ class AMFOperatorCharm(CharmBase):
             self._certificates.on.certificate_expiring, self._on_certificate_expiring
         )
 
-    def _configure_amf(
-        self,
-        event: EventBase,
-    ) -> None:
+    def _configure_amf(self, event: EventBase) -> None:
         """Handle pebble ready event for AMF container.
 
         Args:
@@ -205,6 +203,14 @@ class AMFOperatorCharm(CharmBase):
             logger.debug("Expiring certificate is not the one stored")
             return
         self._request_new_certificate()
+
+    def _on_nrf_broken(self, event: EventBase) -> None:
+        """Event handler for NRF relation broken.
+
+        Args:
+            event (NRFBrokenEvent): Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
 
     def _generate_private_key(self) -> None:
         """Generates and stores private key."""

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,9 @@
-juju==3.2.0.1
 black
 coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+juju
 mypy
 pep8-naming
 pyproject-flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-juju==3.2.0.0
+juju==3.2.0.1
 black
 coverage[toml]
 flake8-docstrings

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,32 +27,32 @@ async def build_and_deploy(ops_test: OpsTest):
     resources = {
         "amf-image": METADATA["resources"]["amf-image"]["upstream-source"],
     }
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         charm,
         resources=resources,
         application_name=APP_NAME,
         trust=True,
     )
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         DB_CHARM_NAME,
         application_name=DB_CHARM_NAME,
         channel="5/edge",
         trust=True,
     )
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,
         channel="edge",
         trust=True,
     )
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         TLS_PROVIDER_CHARM_NAME, application_name=TLS_PROVIDER_CHARM_NAME, channel="edge"
     )
 
 
 @pytest.mark.abort_on_fail
 async def test_deploy_charm_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APP_NAME],
         status="blocked",
         timeout=1000,
@@ -61,15 +61,15 @@ async def test_deploy_charm_and_wait_for_blocked_status(ops_test: OpsTest, build
 
 @pytest.mark.abort_on_fail
 async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.add_relation(
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
-    await ops_test.model.add_relation(
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{APP_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=TLS_PROVIDER_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APP_NAME],
         status="active",
         timeout=1000,
@@ -80,22 +80,22 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
 async def test_remove_nrf_relation_and_wait_for_blocked_status(
     ops_test: OpsTest, build_and_deploy
 ):
-    await ops_test.model.remove_application(NRF_CHARM_NAME, block_until_done=True)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
+    await ops_test.model.remove_application(NRF_CHARM_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
 
 
 @pytest.mark.abort_on_fail
 async def test_restore_nrf_relation_and_wait_for_active_status(
     ops_test: OpsTest, build_and_deploy
 ):
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,
         channel="edge",
         trust=True,
     )
-    await ops_test.model.add_relation(
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -77,17 +77,13 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
 
 
 @pytest.mark.abort_on_fail
-async def test_remove_nrf_relation_and_wait_for_blocked_status(
-    ops_test: OpsTest, build_and_deploy
-):
+async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     await ops_test.model.remove_application(NRF_CHARM_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_nrf_relation_and_wait_for_active_status(
-    ops_test: OpsTest, build_and_deploy
-):
+async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
     await ops_test.model.deploy(  # type: ignore[union-attr]
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -94,4 +94,4 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=300)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
-async def build_and_deploy(ops_test):
+async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     charm = await ops_test.build_charm(".")
     resources = {
@@ -50,10 +51,7 @@ async def build_and_deploy(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_charm_and_wait_for_blocked_status(
-    ops_test,
-    build_and_deploy,
-):
+async def test_deploy_charm_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
         status="blocked",
@@ -62,10 +60,7 @@ async def test_deploy_charm_and_wait_for_blocked_status(
 
 
 @pytest.mark.abort_on_fail
-async def test_relate_and_wait_for_active_status(
-    ops_test,
-    build_and_deploy,
-):
+async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
     await ops_test.model.add_relation(
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
@@ -79,3 +74,28 @@ async def test_relate_and_wait_for_active_status(
         status="active",
         timeout=1000,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_nrf_relation_and_wait_for_blocked_status(
+    ops_test: OpsTest, build_and_deploy
+):
+    await ops_test.model.remove_application(NRF_CHARM_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_nrf_relation_and_wait_for_active_status(
+    ops_test: OpsTest, build_and_deploy
+):
+    await ops_test.model.deploy(
+        NRF_CHARM_NAME,
+        application_name=NRF_CHARM_NAME,
+        channel="edge",
+        trust=True,
+    )
+    await ops_test.model.add_relation(
+        relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
+    )
+    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=60)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -81,7 +81,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.check_output")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
-    def test_given_amf_charm_in_active_state_when_nrf_relation_brakes_then_status_is_blocked(
+    def test_given_amf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
         self,
         patch_is_resource_created,
         patch_nrf_url,


### PR DESCRIPTION
# Description

This PR adds handling of the NRF relation broken event. 
If NRF will ever go down, the AMF charm will reflect that fact by going into `Blocked` state.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library