### PR TITLE
Enable auto-merging Renovate PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @canonical/telco
+*       app/renovate-approve

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,12 @@
     "fileMatch": [
       "^tox.ini$"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
+  "platformAutomerge": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops==2.4.1
+ops
 lightkube
 lightkube-models
 pydantic


### PR DESCRIPTION
# Description

Enables auto-merging of Renovate PRs if minor version of patch was changed.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library