### PR TITLE
Add mandatory certificates integration for NRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy sdcore-nrf --trust --channel=edge
 juju deploy self-signed-certificates --channel=beta
 juju integrate sdcore-nrf:database mongodb-k8s
+juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
 juju integrate sdcore-amf:database mongodb-k8s
 juju integrate sdcore-amf:fiveg-nrf sdcore-nrf:fiveg-nrf
 juju integrate sdcore-amf:certificates self-signed-certificates:certificates

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -65,6 +65,9 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
     await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=NRF_CHARM_NAME, relation2=TLS_PROVIDER_CHARM_NAME
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{APP_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
@@ -93,6 +96,7 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
     )
+    await ops_test.model.add_relation(relation1=NRF_CHARM_NAME, relation2=TLS_PROVIDER_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_CHARM_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
 


### PR DESCRIPTION
# Description

Fix integration tests with new mandatory `certificates` relation for NRF.
Updates readme with the new relation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library