### PR TITLE
fix: prevent scaling errors 

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class AMFOperatorCharm(CharmBase):
 
     def _on_install(self, event: InstallEvent) -> None:
         client = Client()
-        client.create(
+        client.apply(
             Service(
                 apiVersion="v1",
                 kind="Service",
@@ -130,9 +130,12 @@ class AMFOperatorCharm(CharmBase):
                     ],
                     type="LoadBalancer",
                 ),
-            )
+            ),
+            # The default for this value is "controller" when using create, so
+            # we use that name here
+            field_manager="controller",
         )
-        logger.info("Created external AMF service")
+        logger.info("Created/asserted existence of external AMF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:
         client = Client()

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,8 +61,15 @@ class AMFOperatorCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.framework.observe(self.on.remove, self._on_remove)
         if not self.unit.is_leader():
-            raise NotImplementedError("Scaling is not implemented for this charm")
+            # NOTE: In cases where leader status is lost before the charm is
+            # finished processing all teardown events, this prevents teardown
+            # event code from running. Luckily, for this charm, none of the
+            # teardown code is necessary to preform if we're removing the
+            # charm.
+            self.unit.status = BlockedStatus("Scaling is not implemented for this charm")
+            return
         self._amf_container_name = self._amf_service_name = "amf"
         self._amf_container = self.unit.get_container(self._amf_container_name)
         self._nrf_requires = NRFRequires(charm=self, relation_name="fiveg-nrf")
@@ -88,7 +95,6 @@ class AMFOperatorCharm(CharmBase):
             self, relation_name="database", database_name=DATABASE_NAME
         )
         self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.remove, self._on_remove)
         self.framework.observe(self.on.config_changed, self._configure_amf)
         self.framework.observe(self.on.database_relation_joined, self._configure_amf)
         self.framework.observe(self._database.on.database_created, self._configure_amf)
@@ -138,13 +144,29 @@ class AMFOperatorCharm(CharmBase):
         logger.info("Created/asserted existence of external AMF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:
-        client = Client()
-        client.delete(
-            Service,
-            namespace=self.model.name,
-            name=f"{self.app.name}-external",
-        )
-        logger.info("Removed external AMF service")
+        # NOTE: We want to preform this removal only if the last remaining unit
+        # is removed. This charm does not support scaling, so it *should* be
+        # the only unit.
+        #
+        # However, to account for the case where the charm was scaled up, and
+        # now needs to be scaled back down, we only remove the service if the
+        # leader is removed. This is presumed to be the only healthy unit, and
+        # therefore the last remaining one when removed (since all other units
+        # will block if they are not leader)
+        #
+        # This is a best effort removal of the service. There are edge cases
+        # where the leader status is removed from the leader unit before all
+        # hooks are finished running. In this case, we will leave behind a
+        # dirty state in k8s, but it will be cleaned up when the juju model is
+        # destroyed. It will be re-used if the charm is re-deployed.
+        if self.unit.is_leader():
+            client = Client()
+            client.delete(
+                Service,
+                namespace=self.model.name,
+                name=f"{self.app.name}-external",
+            )
+            logger.info("Removed external AMF service")
 
     def _configure_amf(self, event: EventBase) -> None:  # noqa C901
         """Handle pebble ready event for AMF container.


### PR DESCRIPTION
Fix part 1:

In case something happens to cause our charm to go down without properly cleaning up the service, use `client.apply()` instead of client.create()`.

`apply()` will ensure the service configuration matches what is expected, but is OK if it already exists, unlike `create()` which will throw an error if the service already exists.

This will also prevent errors when scaling up (even though scaling isn't supported at this time).

Fix part 2:

Block instead of throwing an error. On removal, make a best effort to remove the external loadbalancer service.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library