### PR TITLE
fix: Protect against load balancer service already existing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -56,6 +56,10 @@ CORE_NETWORK_SHORT_NAME = "SDCORE"
 N2_RELATION_NAME = "fiveg-n2"
 
 
+# The default field manager set when using kubectl to create resources
+DEFAULT_FIELD_MANAGER = "controller"
+
+
 class AMFOperatorCharm(CharmBase):
     """Main class to describe juju event handling for the SD-Core AMF operator."""
 
@@ -115,7 +119,7 @@ class AMFOperatorCharm(CharmBase):
 
     def _on_install(self, event: InstallEvent) -> None:
         client = Client()
-        client.create(
+        client.apply(
             Service(
                 apiVersion="v1",
                 kind="Service",
@@ -130,9 +134,10 @@ class AMFOperatorCharm(CharmBase):
                     ],
                     type="LoadBalancer",
                 ),
-            )
+            ),
+            field_manager=DEFAULT_FIELD_MANAGER,
         )
-        logger.info("Created external AMF service")
+        logger.info("Created/asserted existence of external AMF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:
         client = Client()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -963,7 +963,7 @@ class TestCharm(unittest.TestCase):
         patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
 
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.create")
+    @patch("lightkube.core.client.Client.apply")
     def test_when_install_then_external_service_is_created(self, patch_create):
         self.harness.charm.on.install.emit()
 
@@ -987,7 +987,8 @@ class TestCharm(unittest.TestCase):
                         ],
                         type="LoadBalancer",
                     ),
-                )
+                ),
+                field_manager="controller",
             ),
         ]
 


### PR DESCRIPTION
In case something happens to cause our charm to go down without properly cleaning up the service, use `client.apply()` instead of client.create()`.

`apply()` will ensure the service configuration matches what is expected, but is OK if it already exists, unlike `create()` which will throw an error if the service already exists.

This will also prevent errors when scaling up (even though scaling isn't supported at this time).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library