### PR TITLE
fix: go into blocked status if MetalLB is not enabled and N2 relation is set

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -396,14 +396,14 @@ class AMFOperatorCharm(CharmBase):
             self.unit.status = BlockedStatus("Waiting for MetalLB to be enabled")
             return
 
-    def _get_n2_amf_ip(self) -> str:
+    def _get_n2_amf_ip(self) -> Optional[str]:
         """Returns the IP to send for the N2 interface.
 
         If a configuration is provided, it is returned, otherwise
         returns the IP of the external LoadBalancer Service.
 
         Returns:
-            str: IP address of the AMF
+            str/None: IP address of the AMF if available else None
         """
         if configured_ip := self._get_external_amf_ip_config():
             return configured_ip
@@ -646,7 +646,7 @@ class AMFOperatorCharm(CharmBase):
         """Returns the external service IP.
 
         Returns:
-            str: External Service IP
+            str/None: External Service IP if available else None
         """
         client = Client()
         service = client.get(
@@ -666,7 +666,7 @@ class AMFOperatorCharm(CharmBase):
         """Returns the external service hostname.
 
         Returns:
-            str: External Service hostname
+            str: External Service hostname if available else None
         """
         client = Client()
         service = client.get(


### PR DESCRIPTION
# Description

This PR aims to fix #45. The fix catches the `TypeError` exception thrown when trying to access ingress information when MetalLB is not enabled or properly configured, and leverages the validation from the N2 interface to set the charm into blocked status.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library