### PR TITLE
fix: go into blocked status when database relation is removed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -101,6 +101,7 @@ class AMFOperatorCharm(CharmBase):
         self.framework.observe(self.on.remove, self._on_remove)
         self.framework.observe(self.on.config_changed, self._configure_amf)
         self.framework.observe(self.on.database_relation_joined, self._configure_amf)
+        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self._database.on.database_created, self._configure_amf)
         self.framework.observe(self.on.amf_pebble_ready, self._configure_amf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_amf)
@@ -282,6 +283,14 @@ class AMFOperatorCharm(CharmBase):
             event (NRFBrokenEvent): Juju event
         """
         self.unit.status = BlockedStatus("Waiting for fiveg-nrf relation")
+
+    def _on_database_relation_broken(self, event: EventBase) -> None:
+        """Event handler for database relation broken.
+
+        Args:
+            event: Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for database relation")
 
     def _generate_private_key(self) -> None:
         """Generates and stores private key."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -120,3 +120,29 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
     )
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(DB_CHARM_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.deploy(
+        DB_CHARM_NAME,
+        application_name=DB_CHARM_NAME,
+        channel="5/edge",
+        trust=True,
+    )
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=DB_CHARM_NAME)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -27,7 +27,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
 
-    def _database_is_available(self):
+    def _create_database_relation_and_populate_data(self) -> int:
         database_relation_id = self.harness.add_relation("database", "mongodb")
         self.harness.add_relation_unit(
             relation_id=database_relation_id, remote_unit_name="mongodb/0"
@@ -115,7 +115,7 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         nrf_relation_id = self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
         self.harness.remove_relation(nrf_relation_id)
@@ -149,7 +149,7 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
-        database_relation_id = self._database_is_available()
+        database_relation_id = self._create_database_relation_and_populate_data()
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -219,7 +219,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -242,7 +242,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -275,7 +275,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -318,7 +318,7 @@ class TestCharm(unittest.TestCase):
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self.harness.charm._on_certificate_available(event=event)
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         with open("tests/unit/expected_config/config.conf") as expected_config_file:
             expected_content = expected_config_file.read()
@@ -373,7 +373,7 @@ class TestCharm(unittest.TestCase):
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self.harness.charm._on_certificate_available(event=event)
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         with open("tests/unit/expected_config/config.conf") as expected_config_file:
             expected_content = expected_config_file.read()
@@ -425,7 +425,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         patch_push.assert_called_once_with(
             path="/support/TLS/amf.key",
@@ -458,7 +458,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         expected_plan = {
             "services": {
@@ -508,7 +508,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -533,7 +533,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
 
         self.harness.container_pebble_ready(container_name="amf")
 
@@ -594,7 +594,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
@@ -644,7 +644,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config(
             {"external-amf-ip": "2.2.2.2", "external-amf-hostname": "amf.burger.com"}
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
@@ -690,7 +690,7 @@ class TestCharm(unittest.TestCase):
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self.harness.update_config({"external-amf-ip": "2.2.2.2"})
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
@@ -787,7 +787,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
         relation_data = self.harness.get_relation_data(
@@ -833,7 +833,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
         relation_1_id = self.harness.add_relation(
@@ -906,7 +906,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.charm._on_certificates_relation_broken(event=Mock())
         self.assertEqual(
             self.harness.charm.unit.status, BlockedStatus("Waiting for certificates relation")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,6 +41,7 @@ class TestCharm(unittest.TestCase):
                 "uris": "http://dummy",
             },
         )
+        return database_relation_id
 
     @staticmethod
     def _read_file(path: str) -> str:
@@ -122,6 +123,43 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg-nrf relation"),
+        )
+
+    @patch("ops.model.Container.pull")
+    @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.push", new=Mock)
+    @patch("charm.check_output")
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
+    def test_given_amf_charm_in_active_state_when_database_relation_breaks_then_status_is_blocked(
+        self,
+        patch_is_resource_created,
+        patch_nrf_url,
+        patch_check_output,
+        patch_exists,
+        patch_pull,
+    ):
+        patch_pull.return_value = StringIO(
+            self._read_file("tests/unit/expected_config/config.conf").strip()
+        )
+        patch_exists.return_value = True
+        patch_check_output.return_value = b"1.1.1.1"
+        patch_exists.return_value = True
+        patch_is_resource_created.return_value = True
+        patch_nrf_url.return_value = "http://nrf:8081"
+        self.harness.set_can_connect(container="amf", val=True)
+        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        database_relation_id = self._database_is_available()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.container_pebble_ready("amf")
+
+        self.harness.remove_relation(database_relation_id)
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Waiting for database relation"),
         )
 
     @patch("charm.generate_private_key")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -737,7 +737,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")


### PR DESCRIPTION
# Description

This PR aims to fix #49. When database relation is removed, move into Blocked status.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library