### PR TITLE
chore: Fix unit test for database relation broken

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -804,7 +804,9 @@ class TestCharm(unittest.TestCase):
 
         with self.assertRaises(FileNotFoundError):
             (root / "support/TLS/amf.key").read_text()
+        with self.assertRaises(FileNotFoundError):
             (root / "support/TLS/amf.pem").read_text()
+        with self.assertRaises(FileNotFoundError):
             (root / "support/TLS/amf.csr").read_text()
 
     @patch("charm.check_output")


### PR DESCRIPTION
# Description

This PR aims to fix a wrong validation inside a unit test. The assertion on private key, certificate and signing request removal after database relation broken event should be performed for each single file and not in bulk.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library