### PR TITLE
chore: Replacing KubernetesServicePatch with ops.set_ports

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -10,9 +10,6 @@ from subprocess import check_output
 from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # type: ignore[import]
-from charms.observability_libs.v1.kubernetes_service_patch import (  # type: ignore[import]
-    KubernetesServicePatch,
-)
 from charms.prometheus_k8s.v0.prometheus_scrape import (  # type: ignore[import]
     MetricsEndpointProvider,
 )
@@ -86,14 +83,7 @@ class AMFOperatorCharm(CharmBase):
                 }
             ],
         )
-        self._service_patcher = KubernetesServicePatch(
-            charm=self,
-            ports=[
-                ServicePort(name="prometheus-exporter", port=PROMETHEUS_PORT),
-                ServicePort(name="sbi", port=SBI_PORT),
-                ServicePort(name="sctp-grpc", port=SCTP_GRPC_PORT),
-            ],
-        )
+        self.unit.set_ports(PROMETHEUS_PORT, SBI_PORT, SCTP_GRPC_PORT)
         self._database = DatabaseRequires(
             self, relation_name="database", database_name=DATABASE_NAME
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,10 +14,6 @@ from charm import AMFOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
-    @patch(
-        "charm.KubernetesServicePatch",
-        lambda charm, ports: None,
-    )
     def setUp(self):
         self.namespace = "whatever"
         self.harness = testing.Harness(AMFOperatorCharm)


### PR DESCRIPTION
# Description

This PR replaces `KubernetesServicePatch` with `ops.set_ports` for setting the ports exposed by the workload.
It's worth noting, that with ops.set_ports we're not able to set custom name for the port. ops will automatically set the name of the port to `juju-{PORT_NUMBER}-tcp`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library