### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-amf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-amf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-amf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-amf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
   lib-needs-publishing:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           filters: |
             fiveg_n2:
-              - 'lib/charms/sdcore_amf/v0/fiveg_n2.py'
+              - 'lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py'
 
   publish-lib:
     name: Publish Lib
@@ -63,5 +63,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }} && ${{ needs.changes.outputs.needs-publishing == 'true' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:
-      lib-name: "charms.sdcore_amf.v0.fiveg_n2"
+      lib-name: "charms.sdcore_amf_k8s.v0.fiveg_n2"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core AMF Operator for K8s
+# SD-Core AMF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-amf-k8s/badge.svg)](https://charmhub.io/sdcore-amf-k8s)
 
 Charmed Operator for SD-Core's Access and Mobility Management Function (AMF) for K8s.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core AMF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-amf/badge.svg)](https://charmhub.io/sdcore-amf)
+# SD-Core AMF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-amf-k8s/badge.svg)](https://charmhub.io/sdcore-amf-k8s)
 
-Charmed Operator for SD-Core's Access and Mobility Management Function (AMF).
+Charmed K8s Operator for SD-Core's Access and Mobility Management Function (AMF).
 
 
 ## Pre-requisites
@@ -11,15 +11,15 @@ Juju model on a Kubernetes cluster.
 ## Usage
 
 ```bash
-juju deploy sdcore-amf --trust --channel=edge
+juju deploy sdcore-amf-k8s --trust --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy sdcore-nrf --channel=edge
+juju deploy sdcore-nrf-k8s --channel=edge
 juju deploy self-signed-certificates --channel=beta
-juju integrate sdcore-nrf:database mongodb-k8s
-juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
-juju integrate sdcore-amf:database mongodb-k8s
-juju integrate sdcore-amf:fiveg-nrf sdcore-nrf:fiveg-nrf
-juju integrate sdcore-amf:certificates self-signed-certificates:certificates
+juju integrate sdcore-nrf-k8s:database mongodb-k8s
+juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-amf-k8s:database mongodb-k8s
+juju integrate sdcore-amf-k8s:fiveg-nrf sdcore-nrf-k8s:fiveg-nrf
+juju integrate sdcore-amf-k8s:certificates self-signed-certificates:certificates
 ```
 
 ### Overriding external access information for N2 interface
@@ -30,7 +30,7 @@ your network configuration, you can override that information through
 configuration:
 
 ```bash
-juju config sdcore-amf external-amf-ip=192.168.0.4 external-amf-hostname=amf.example.com
+juju config sdcore-amf-k8s external-amf-ip=192.168.0.4 external-amf-hostname=amf.example.com
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core AMF K8s Operator
+# SD-Core AMF Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-amf-k8s/badge.svg)](https://charmhub.io/sdcore-amf-k8s)
 
-Charmed K8s Operator for SD-Core's Access and Mobility Management Function (AMF).
+Charmed Operator for SD-Core's Access and Mobility Management Function (AMF) for K8s.
 
 
 ## Pre-requisites

--- a/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py
+++ b/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py
@@ -14,7 +14,7 @@ to be able to provide or consume information on connectivity to the N2 plane.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_amf.v0.fiveg_n2
+charmcraft fetch-lib charms.sdcore_amf_k8s.v0.fiveg_n2
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -30,7 +30,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_amf.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
+from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_amf.v0.fiveg_n2 import N2Provides
+from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Provides
 
 
 class DummyFivegN2ProviderCharm(CharmBase):
@@ -105,12 +105,12 @@ from ops.model import Relation
 from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "3bb439930da24fd09631af74f70ea394"
+LIBID = "396917943b9b4b6989166b77c97a9fb8"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-# Increment this PATCH version before using `charmcraft push-lib` or reset
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,11 +1,11 @@
-name: sdcore-amf
-display-name: SD-Core AMF
+name: sdcore-amf-k8s
+display-name: SD-Core AMF K8s
 summary: A Charmed Operator for SD-Core's Access and Mobility Management Function (AMF).
 description: |
   A Charmed Operator for SD-Core's Access and Mobility Management Function (AMF).
-website: https://charmhub.io/sdcore-amf
-source: https://github.com/canonical/sdcore-amf-operator
-issues: https://github.com/canonical/sdcore-amf-operator/issues
+website: https://charmhub.io/sdcore-amf-k8s
+source: https://github.com/canonical/sdcore-amf-k8s-operator
+issues: https://github.com/canonical/sdcore-amf-k8s-operator/issues
 
 containers:
   amf:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ profile = "black"
 max-line-length = 99
 max-doc-length = 99
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "lib/charms/data_platform_libs", "lib/charms/observability_libs", "lib/charms/prometheus_k8s", "lib/charms/sdcore_nrf"]
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "lib/charms/data_platform_libs", "lib/charms/observability_libs", "lib/charms/prometheus_k8s", "lib/charms/sdcore_nrf_k8s"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore D107 Missing docstring in __init__
 ignore = ["D107"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,8 +57,8 @@ N2_RELATION_NAME = "fiveg-n2"
 DEFAULT_FIELD_MANAGER = "controller"
 
 
-class AMFOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core AMF operator."""
+class AMFK8sOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core AMF K8s operator."""
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -693,4 +693,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(AMFOperatorCharm)
+    main(AMFK8sOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,8 +13,8 @@ from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # typ
 from charms.prometheus_k8s.v0.prometheus_scrape import (  # type: ignore[import]
     MetricsEndpointProvider,
 )
-from charms.sdcore_amf.v0.fiveg_n2 import N2Provides  # type: ignore[import]
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Provides  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core AMF service."""
+"""Charmed operator for the SD-Core AMF service for K8s."""
 
 import logging
 from ipaddress import IPv4Address
@@ -57,8 +57,8 @@ N2_RELATION_NAME = "fiveg-n2"
 DEFAULT_FIELD_MANAGER = "controller"
 
 
-class AMFK8sOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core AMF K8s operator."""
+class AMFOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core AMF operator for K8s."""
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -693,4 +693,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(AMFK8sOperatorCharm)
+    main(AMFOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 DB_CHARM_NAME = "mongodb-k8s"
-NRF_CHARM_NAME = "sdcore-nrf"
+NRF_CHARM_NAME = "sdcore-nrf-k8s"
 TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 
 

--- a/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_provider_interface.py
+++ b/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_provider_interface.py
@@ -8,7 +8,7 @@ import pytest
 from ops import testing
 from ops.charm import CharmBase, RelationJoinedEvent
 
-from lib.charms.sdcore_amf.v0.fiveg_n2 import N2Provides
+from lib.charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Provides
 
 METADATA = """
 name: fiveg-n2-provider

--- a/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_requirer_interface.py
@@ -8,7 +8,7 @@ from unittest.mock import call, patch
 from ops import testing
 from ops.charm import CharmBase
 
-from lib.charms.sdcore_amf.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
+from lib.charms.sdcore_amf_k8s.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
 
 METADATA = """
 name: fiveg-n2-requirer
@@ -23,7 +23,7 @@ requires:
 
 logger = logging.getLogger(__name__)
 
-CHARM_LIB_PATH = "lib.charms.sdcore_amf.v0.fiveg_n2"
+CHARM_LIB_PATH = "lib.charms.sdcore_amf_k8s.v0.fiveg_n2"
 
 
 class DummyFivegN2Requires(CharmBase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,13 +10,13 @@ from lightkube.resources.core_v1 import Service
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import AMFK8sOperatorCharm
+from charm import AMFOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
         self.namespace = "whatever"
-        self.harness = testing.Harness(AMFK8sOperatorCharm)
+        self.harness = testing.Harness(AMFOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -87,7 +87,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_amf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
         self,
@@ -111,7 +111,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_amf_charm_in_active_state_when_database_relation_breaks_then_status_is_blocked(
         self,
@@ -202,7 +202,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_storage_not_attached_when_pebble_ready_then_status_is_waiting(
         self, patch_is_resource_created, patch_nrf_url, patch_generate_private_key
@@ -226,7 +226,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.check_output")
     @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_certificates_not_stored_when_pebble_ready_then_status_is_waiting(
         self,
@@ -256,7 +256,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.check_output")
     @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_created_and_database_available_and_nrf_data_available_and_certs_stored_when_pebble_ready_then_config_file_rendered_and_pushed_correctly(  # noqa: E501
         self,
@@ -292,7 +292,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.check_output")
     @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_content_of_config_file_changed_when_pebble_ready_then_config_file_is_rendered_and_pushed(  # noqa: E501
         self,
@@ -334,7 +334,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.check_output")
     @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_content_of_config_file_not_changed_when_pebble_ready_then_config_file_is_not_pushed(  # noqa: E501
         self,
@@ -367,7 +367,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_available_and_config_pushed_when_pebble_ready_then_pebble_is_applied_correctly(  # noqa: E501
         self,
@@ -415,7 +415,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(expected_plan, updated_plan)
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
@@ -447,7 +447,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_empty_ip_address_when_pebble_ready_then_status_is_waiting(
         self,
         patch_nrf_url,
@@ -489,7 +489,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_when_fiveg_n2_relation_joined_then_n2_information_is_in_relation_databag(  # noqa: E501
         self,
@@ -533,7 +533,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_and_n2_config_is_overriden_when_fiveg_n2_relation_joined_then_custom_n2_information_is_in_relation_databag(  # noqa: E501
         self,
@@ -580,7 +580,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_and_lb_service_has_no_hostname_when_fiveg_n2_relation_joined_then_internal_service_hostname_is_used(  # noqa: E501
         self,
@@ -625,7 +625,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_and_metallb_service_is_not_available_when_fiveg_n2_relation_joined_then_amf_goes_in_blocked_state(  # noqa: E501
         self,
@@ -663,7 +663,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_service_starts_running_after_n2_relation_joined_when_pebble_ready_then_n2_information_is_in_relation_databag(  # noqa: E501
         self,
@@ -713,7 +713,7 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.get")
     @patch("charm.generate_private_key")
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_more_than_one_n2_requirers_join_n2_relation_when_service_starts_then_n2_information_is_in_relation_databag(  # noqa: E501
         self,
@@ -805,7 +805,7 @@ class TestCharm(unittest.TestCase):
             (root / "support/TLS/amf.csr").read_text()
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_status_is_blocked(  # noqa: E501
         self,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,13 +10,13 @@ from lightkube.resources.core_v1 import Service
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import AMFOperatorCharm
+from charm import AMFK8sOperatorCharm
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
         self.namespace = "whatever"
-        self.harness = testing.Harness(AMFOperatorCharm)
+        self.harness = testing.Harness(AMFK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)
@@ -618,7 +618,7 @@ class TestCharm(unittest.TestCase):
         )
         self.assertEqual(relation_data["amf_ip_address"], "2.2.2.2")
         self.assertEqual(
-            relation_data["amf_hostname"], "sdcore-amf-external.whatever.svc.cluster.local"
+            relation_data["amf_hostname"], "sdcore-amf-k8s-external.whatever.svc.cluster.local"
         )
         self.assertEqual(relation_data["amf_port"], "38412")
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint, unit, static
 src_path = {toxinidir}/src/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-lib_path = {toxinidir}/lib/charms/sdcore_amf/v0/
+lib_path = {toxinidir}/lib/charms/sdcore_amf_k8s/v0/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit).

- Create new fiveg_n2 library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library